### PR TITLE
Refactor to support async classification

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@fortawesome/react-fontawesome": "^0.1.8",
     "@loadable/component": "^5.11.0",
     "axios": "^0.19.0",
-    "bayes": "^0.0.7",
+    "bayes": "^1.0.0",
     "bootstrap": "^4.4.1",
     "d3-array": "^2.4.0",
     "d3-collection": "^1.0.7",

--- a/src/actions.js
+++ b/src/actions.js
@@ -358,7 +358,7 @@ export const guessAllCategories = (requireConfirmed = true) => {
     // Guess 100 transactions at a time with a bit of sleeping in between to
     // avoid locking the UI completely.
     const transactionsToGuess = chunk(
-      state.transactions.data.filter(t => !t.category.confirmed && !t.ignore),
+      state.transactions.data.filter(t => !t.category.confirmed),
       100
     );
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,5 +1,6 @@
 import chunk from 'lodash/chunk';
 import { sleep, fillDates } from './util';
+import { updateCategorizer, guessCategory, retrainCategorizer } from './ml';
 import { lambdaBase } from './config';
 
 // Import actions
@@ -21,12 +22,14 @@ export const DELETE_ACCOUNT = 'DELETE_ACCOUNT';
 // Category actions
 export const ADD_CATEGORY = 'ADD_CATEGORY';
 export const UPDATE_CATEGORY = 'UPDATE_CATEGORY';
-export const DELETE_CATEGORY = 'DELETE_CATEGORY';
+export const DELETE_CATEGORY_START = 'DELETE_CATEGORY_START';
+export const DELETE_CATEGORY_END = 'DELETE_CATEGORY_END';
 
 // Transaction actions
-export const GUESS_CATEGORY_FOR_ROW = 'GUESS_CATEGORY_FOR_ROW';
-export const CATEGORIZE_ROW = 'CATEGORIZE_ROW';
-export const CATEGORIZE_ROWS = 'CATEGORIZE_ROWS';
+export const CATEGORIZE_ROW_START = 'CATEGORIZE_ROW_START';
+export const CATEGORIZE_ROW_END = 'CATEGORIZE_ROW_END';
+export const GUESS_ALL_CATEGORIES_START = 'GUESS_ALL_CATEGORIES_START';
+export const GUESS_ALL_CATEGORIES_END = 'GUESS_ALL_CATEGORIES_END';
 export const IGNORE_TRANSACTION = 'IGNORE_TRANSACTION';
 export const DELETE_TRANSACTION = 'DELETE_TRANSACTION';
 export const GROUP_TRANSACTIONS = 'GROUP_TRANSACTIONS';
@@ -37,8 +40,6 @@ export const TOGGLE_LOCAL_STORAGE = 'TOGGLE_LOCAL_STORAGE';
 export const RESTORE_STATE_FROM_FILE = 'RESTORE_STATE_FROM_FILE';
 export const EDIT_DATES = 'EDIT_DATES';
 export const CREATE_TEST_DATA = 'CREATE_TEST_DATA';
-export const START_GUESS_ALL_CATEGORIES = 'START_GUESS_ALL_CATEGORIES';
-export const END_GUESS_ALL_CATEGORIES = 'END_GUESS_ALL_CATEGORIES';
 export const SET_CURRENCIES = 'SET_CURRENCIES';
 export const SET_CURRENCY_RATES = 'SET_CURRENCY_RATES';
 export const START_FETCH_CURRENCIES = 'START_FETCH_CURRENCIES';
@@ -151,28 +152,6 @@ export const deleteAccount = accountId => {
   };
 };
 
-export const guessCategoryForRow = rowId => {
-  return {
-    type: GUESS_CATEGORY_FOR_ROW,
-    rowId
-  };
-};
-
-export const categorizeRow = (rowId, categoryId) => {
-  return {
-    type: CATEGORIZE_ROW,
-    rowId,
-    categoryId
-  };
-};
-
-export const categorizeRows = rowCategoryMapping => {
-  return {
-    type: CATEGORIZE_ROWS,
-    rowCategoryMapping
-  };
-};
-
 export const ignoreTransaction = (transactionId, ignore) => {
   return {
     type: IGNORE_TRANSACTION,
@@ -202,6 +181,20 @@ export const deleteTransactionGroup = transactionGroupId => {
   };
 };
 
+export const categorizeRowStart = () => {
+  return {
+    type: CATEGORIZE_ROW_START
+  };
+};
+
+export const categorizeRowEnd = (transactionCategoryMapping, categorizerConfig) => {
+  return {
+    type: CATEGORIZE_ROW_END,
+    transactionCategoryMapping,
+    categorizerConfig
+  };
+};
+
 export const restoreStateFromFile = newState => {
   return {
     type: RESTORE_STATE_FROM_FILE,
@@ -217,25 +210,6 @@ export const addCategory = (name, parentId) => {
   };
 };
 
-export const addCategoryWithRow = (name, parentId, rowId) => {
-  return (dispatch, getState) => {
-    // First add the new category
-    dispatch(addCategory(name, parentId));
-
-    // Then find the updated categories so we can get the category ID.
-    // The new category is probably the last one in the array, but just to be
-    // safe, let's loop through them... but backwards for that wee bit of extra
-    // speed :-)
-    const categories = getState().categories.data;
-    for (let i = categories.length - 1; i >= 0; i--) {
-      if (categories[i].name === name) {
-        dispatch(categorizeRow(rowId, categories[i].id));
-        break;
-      }
-    }
-  };
-};
-
 export const updateCategory = (categoryId, name, parentId) => {
   return {
     type: UPDATE_CATEGORY,
@@ -245,10 +219,18 @@ export const updateCategory = (categoryId, name, parentId) => {
   };
 };
 
-export const deleteCategory = categoryId => {
+export const deleteCategoryStart = categoryId => {
   return {
-    type: DELETE_CATEGORY,
+    type: DELETE_CATEGORY_START,
     categoryId
+  };
+};
+
+export const deleteCategoryEnd = (categoryId, categorizerConfig) => {
+  return {
+    type: DELETE_CATEGORY_END,
+    categoryId,
+    categorizerConfig
   };
 };
 
@@ -322,8 +304,11 @@ export const setEmptyTransactionsAccount = accountId => {
 
 export const createTestData = () => ({ type: CREATE_TEST_DATA });
 
-export const startGuessAllCategories = () => ({ type: START_GUESS_ALL_CATEGORIES });
-export const endGuessAllCategories = () => ({ type: END_GUESS_ALL_CATEGORIES });
+export const guessAllCategoriesStart = () => ({ type: GUESS_ALL_CATEGORIES_START });
+export const guessAllCategoriesEnd = transactionCategoryMapping => ({
+  type: GUESS_ALL_CATEGORIES_END,
+  transactionCategoryMapping
+});
 
 export const startFetchCurrencies = () => ({ type: START_FETCH_CURRENCIES });
 export const endFetchCurrencies = () => ({ type: END_FETCH_CURRENCIES });
@@ -345,7 +330,7 @@ export const setCurrencyRates = currencyRates => {
   };
 };
 
-export const guessAllCategories = () => {
+export const guessAllCategories = (requireConfirmed = true) => {
   return async (dispatch, getState) => {
     // Do not start guessing until the previous guessing is done.
     // Note: This can potentially queue up a lot of guessing, but in practice
@@ -353,40 +338,98 @@ export const guessAllCategories = () => {
     while (getState().edit.isCategoryGuessing) {
       await sleep(100);
     }
-    // Determine the diversity of currently confirmed categories.
-    // Do not start guessing if we have less than 3 confirmed categories.
-    const confirmedCategories = new Set(
-      getState().transactions.data
-        .filter(t => !!t.category.confirmed)
-        .map(t => t.category.confirmed)
-    );
-    if (confirmedCategories.size < 3) return;
+
+    const state = getState();
+
+    if (requireConfirmed) {
+      // Determine the diversity of currently confirmed categories.
+      // Do not start guessing if we have less than 3 confirmed categories.
+      const confirmedCategories = new Set(
+        state.transactions.data
+          .filter(t => !!t.category.confirmed)
+          .map(t => t.category.confirmed)
+      );
+      if (confirmedCategories.size < 3) return;
+    }
 
     // Signal to everyone that we are starting the guessing game.
-    dispatch(startGuessAllCategories());
+    dispatch(guessAllCategoriesStart());
 
     // Guess 100 transactions at a time with a bit of sleeping in between to
     // avoid locking the UI completely.
     const transactionsToGuess = chunk(
-      getState().transactions.data
-        .reduce((arr, t, i) => {
-          // Store the index of the transaction rather than the ID.
-          // XXX: This is going to cause race conditions if transactions are
-          // somehow changed between sleeping (see below), but this will not
-          // happen in practice, and it is necessary optimization.
-          if (!t.category.confirmed && !t.ignore) arr.push(i);
-          return arr;
-        }, []),
+      state.transactions.data.filter(t => !t.category.confirmed && !t.ignore),
       100
     );
 
+    const transactionCategoryMapping = {};
+
     for (let i = 0; i < transactionsToGuess.length; i++) {
-      await dispatch(guessCategoryForRow(transactionsToGuess[i]));
+      const guessMapping = await guessCategory(
+        transactionsToGuess[i],
+        state.transactions.categorizer
+      );
+      for (const [key, value] of Object.entries(guessMapping)) {
+        transactionCategoryMapping[key] = value;
+      }
       await sleep(10);
     }
 
-    // Signal that we are done
-    dispatch(endGuessAllCategories());
+    // Signal that we are done, and update all the guesses.
+    dispatch(guessAllCategoriesEnd(transactionCategoryMapping));
+  };
+};
+
+export const categorizeRows = rowCategoryMapping => {
+  return async (dispatch, getState) => {
+    dispatch(categorizeRowStart());
+    const state = getState();
+    const categorizerConfig = await updateCategorizer(
+      state.transactions.data,
+      state.transactions.categorizer.bayes,
+      rowCategoryMapping
+    );
+    dispatch(categorizeRowEnd(rowCategoryMapping, categorizerConfig));
+  };
+};
+
+export const categorizeRow = (rowId, categoryId) => {
+  const rowCategoryMapping = { [rowId]: categoryId };
+  return categorizeRows(rowCategoryMapping);
+};
+
+export const addCategoryWithRow = (name, parentId, rowId) => {
+  return async (dispatch, getState) => {
+    // First add the new category
+    dispatch(addCategory(name, parentId));
+
+    // Then find the updated categories so we can get the category ID.
+    // The new category is probably the last one in the array, but just to be
+    // safe, let's loop through them... but backwards for that wee bit of extra
+    // speed :-)
+    const categories = getState().categories.data;
+    for (let i = categories.length - 1; i >= 0; i--) {
+      if (categories[i].name === name) {
+        await dispatch(categorizeRow(rowId, categories[i].id));
+        break;
+      }
+    }
+  };
+};
+
+export const deleteCategory = categoryId => {
+  return async (dispatch, getState) => {
+    dispatch(deleteCategoryStart(categoryId));
+
+    // Retrain the categorizer...
+    // Even though deleteCategoryStart above might actually reset the category
+    // and transaction data, it is slightly safer to manually remove the
+    // transactions with the given category ID when retraining the classifier.
+    // Also, it makes the tests work :D :D :D
+    const transactions = getState().transactions.data.filter(t => t.category.confirmed !== categoryId);
+    const categorizerConfig = await retrainCategorizer(transactions);
+
+    dispatch(deleteCategoryEnd(categoryId, categorizerConfig));
   };
 };
 

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -4,30 +4,44 @@ import * as actions from './actions';
 
 const mockStore = configureStore([thunk]);
 
-it('should dispatch and add category and categorize row', () => {
-  // Mock store does not call any reducers, so adding the category is done to
-  // fake the adding of the category. The add category functionality itself is
-  // tested in the reducer tests.
-  const store = mockStore({
-    categories: {
-      data: [{ id: 'abcd', name: 'Hobby' }]
-    }
-  });
+describe('addCategoryWithRow', () => {
+  it('should dispatch and add category and categorize row', async () => {
+    // Mock store does not call any reducers
+    const store = mockStore({
+      categories: {
+        data: [{ id: 'abcd', name: 'Hobby' }]
+      },
+      transactions: {
+        data: [{ id: 'efgh', category: {}, descriptionCleaned: 'works nicely' }],
+        categorizer: {
+          bayes: ''
+        },
+      }
+    });
 
-  store.dispatch(actions.addCategoryWithRow('Hobby', '', 'efgh'));
+    await store.dispatch(actions.addCategoryWithRow('Hobby', '', 'efgh'));
 
-  expect(store.getActions()).toEqual([
-    {
+    const calledActions = store.getActions();
+
+    // The category is added and row categorization starts.
+
+    expect(calledActions[0]).toEqual({
       type: actions.ADD_CATEGORY,
       name: 'Hobby',
       parentId: ''
-    },
-    {
-      type: actions.CATEGORIZE_ROW,
-      categoryId: 'abcd',
-      rowId: 'efgh'
-    },
-  ]);
+    })
+
+    expect(calledActions[1]).toEqual({
+      type: actions.CATEGORIZE_ROW_START,
+    });
+
+    expect(calledActions[2].type).toEqual(actions.CATEGORIZE_ROW_END);
+    expect(calledActions[2].transactionCategoryMapping).toEqual({
+      'efgh': 'abcd'
+    });
+
+    expect(calledActions[2].categorizerConfig).toBeTruthy();
+  });
 });
 
 describe('fetchCurrencies', () => {
@@ -147,5 +161,295 @@ describe('fetchCurrencyRates', () => {
         type: actions.END_FETCH_CURRENCY_RATES
       },
     ]);
+  });
+});
+
+describe('guessAllCategories', () => {
+  const baseData = {
+    edit: {
+      isCategoryGuessing: false,
+    },
+    transactions: {
+      categorizer: {
+        // A bayes classifier, trained on apple and origami
+        bayes: '{"categories":{"hobby":true,"food":true},"docCount":{"hobby":1,"food":1},"totalDocuments":2,"vocabulary":{"origami":true,"apple":true},"vocabularySize":2,"wordCount":{"hobby":1,"food":1},"wordFrequencyCount":{"hobby":{"origami":1},"food":{"apple":1}},"options":{}}'
+      },
+      data: [
+        {
+          id: 'a',
+          descriptionCleaned: 'more origami',
+          category: {
+            guess: '',
+            confirmed: ''
+          }
+        },
+        {
+          id: 'b',
+          descriptionCleaned: 'more origami',
+          category: {
+            guess: '',
+            confirmed: 'hobby' // Already classified
+          }
+        },
+        {
+          id: 'c',
+          descriptionCleaned: 'apple apple',
+          category: {
+            guess: '',
+            confirmed: ''
+          }
+        }
+      ]
+    }
+  };
+
+  it('should require some confirmed categories by default', async () => {
+    const store = mockStore(baseData);
+    await store.dispatch(actions.guessAllCategories());
+    expect(store.getActions()).toEqual([]);
+  })
+
+  it('should guess the categories', async () => {
+    const store = mockStore(baseData);
+
+    await store.dispatch(actions.guessAllCategories(false));
+    const calledActions = store.getActions();
+
+    expect(calledActions[0]).toEqual({
+      type: actions.GUESS_ALL_CATEGORIES_START
+    });
+
+    expect(calledActions[1].type).toEqual(actions.GUESS_ALL_CATEGORIES_END);
+    expect(calledActions[1].transactionCategoryMapping).toEqual({
+      'a': 'hobby',
+      'c': 'food'
+    });
+  });
+});
+
+describe('categorizeRow', () => {
+  it('should add a confirmed category to the classifier', async () => {
+    const store = mockStore({
+      transactions: {
+        categorizer: {
+          bayes: ''
+        },
+        data: [
+          {
+            id: 'abcd',
+            description: 'origami',
+            category: {
+              guess: 'travel',
+              confirmed: ''
+            }
+          }
+        ]
+      }
+    });
+
+    await store.dispatch(actions.categorizeRow('abcd', 'hobby'));
+
+    const calledActions = store.getActions();
+
+    // The category is added and row categorization starts.
+
+    expect(calledActions[0]).toEqual({
+      type: actions.CATEGORIZE_ROW_START,
+    });
+
+    expect(calledActions[1].type).toEqual(actions.CATEGORIZE_ROW_END);
+    expect(calledActions[1].transactionCategoryMapping).toEqual({
+      'abcd': 'hobby'
+    });
+
+    expect(calledActions[1].categorizerConfig.bayes).toEqual(
+      // Expecting it to be trained on one row now :-)
+      '{"categories":{"hobby":true},"docCount":{"hobby":1},"totalDocuments":1,"vocabulary":{"origami":true},"vocabularySize":1,"wordCount":{"hobby":1},"wordFrequencyCount":{"hobby":{"origami":1}},"options":{}}'
+    );
+  });
+
+  it('should retrain the classifier when a category changes', async () => {
+    const store = mockStore({
+      transactions: {
+        categorizer: {
+          bayes: '{"categories":{"hobby":true},"docCount":{"hobby":1},"totalDocuments":1,"vocabulary":{"origami":true},"vocabularySize":1,"wordCount":{"hobby":1},"wordFrequencyCount":{"hobby":{"origami":1}},"options":{}}'
+        },
+        data: [
+          {
+            id: 'abcd',
+            description: 'origami',
+            category: {
+              confirmed: 'hobby'
+            }
+          }
+        ]
+      }
+    });
+
+    await store.dispatch(actions.categorizeRow('abcd', 'food'));
+    const calledActions = store.getActions();
+
+    expect(calledActions[1].categorizerConfig.bayes).toEqual(
+      // Expecting it to not know about hobby anymore because origami is now food for some reason.
+      '{"categories":{"food":true},"docCount":{"food":1},"totalDocuments":1,"vocabulary":{"origami":true},"vocabularySize":1,"wordCount":{"food":1},"wordFrequencyCount":{"food":{"origami":1}},"options":{}}'
+    );
+  });
+
+  it('should not add empty categories to classifier', async () => {
+    const store = mockStore({
+      transactions: {
+        categorizer: {
+          bayes: ''
+        },
+        data: [
+          {
+            id: 'abcd',
+            description: 'origami',
+            category: {
+              guess: 'travel',
+              confirmed: ''
+            }
+          }
+        ]
+      }
+    });
+
+    await store.dispatch(actions.categorizeRow('abcd', ''));
+    const calledActions = store.getActions();
+
+    // Expect and empty classifier because the category is empty.
+    expect(calledActions[1].categorizerConfig.bayes).toEqual(
+      '{"categories":{},"docCount":{},"totalDocuments":0,"vocabulary":{},"vocabularySize":0,"wordCount":{},"wordFrequencyCount":{},"options":{}}'
+    );
+  });
+
+  it('should not add empty descriptions to classifier', async () => {
+    const store = mockStore({
+      transactions: {
+        categorizer: {
+          bayes: ''
+        },
+        data: [
+          {
+            id: 'abcd',
+            description: '',
+            category: {
+              guess: 'travel',
+              confirmed: ''
+            }
+          }
+        ]
+      }
+    });
+
+    await store.dispatch(actions.categorizeRow('abcd', 'hobby'));
+    const calledActions = store.getActions();
+
+    // Expect and empty classifier because the category is empty.
+    expect(calledActions[1].categorizerConfig.bayes).toEqual(
+      '{"categories":{},"docCount":{},"totalDocuments":0,"vocabulary":{},"vocabularySize":0,"wordCount":{},"wordFrequencyCount":{},"options":{}}'
+    );
+  });
+});
+
+describe('categorizeRows', () => {
+  const baseData = {
+    transactions: {
+      categorizer: {
+        bayes: ''
+      },
+      data: [
+        {
+          id: 'abcd',
+          description: 'origami',
+          descriptionCleaned: 'origami',
+          category: {
+            guess: 'travel',
+            confirmed: ''
+          }
+        },
+        {
+          id: 'efgh',
+          description: 'hotel',
+          category: {
+            guess: 'travel',
+            confirmed: ''
+          }
+        }
+      ]
+    }
+  };
+
+  it('should add a confirmed category to multiple rows', async () => {
+    const store = mockStore(baseData);
+
+    await store.dispatch(actions.categorizeRows({
+      abcd: 'hobby',
+      efgh: 'travel'
+    }));
+    const calledActions = store.getActions();
+
+    // Expect and empty classifier because the category is empty.
+    expect(calledActions[1].transactionCategoryMapping).toEqual({
+      abcd: 'hobby',
+      efgh: 'travel'
+    });
+
+    expect(calledActions[1].categorizerConfig.bayes).toEqual(
+      '{"categories":{"hobby":true,"travel":true},"docCount":{"hobby":1,"travel":1},"totalDocuments":2,"vocabulary":{"origami":true,"hotel":true},"vocabularySize":2,"wordCount":{"hobby":1,"travel":1},"wordFrequencyCount":{"hobby":{"origami":1},"travel":{"hotel":1}},"options":{}}'
+    );
+  });
+});
+
+describe('deleteCategory', () => {
+  it('should reset categories and retrain categorizer when a category is removed', async () => {
+    const store = mockStore({
+      transactions: {
+        categorizer: {
+          // trained on apple and origami
+          bayes: '{"categories":{"hobby":true,"food":true},"docCount":{"hobby":1,"food":1},"totalDocuments":2,"vocabulary":{"origami":true,"apple":true},"vocabularySize":2,"wordCount":{"hobby":1,"food":1},"wordFrequencyCount":{"hobby":{"origami":1},"food":{"apple":1}},"options":{}}'
+        },
+        data: [
+          {
+            category: {
+              guess: 'food',
+              confirmed: ''
+            }
+          },
+          {
+            description: 'apple',
+            category: {
+              guess: '',
+              confirmed: 'food'
+            }
+          },
+          {
+            description: 'origami',
+            category: {
+              guess: '',
+              confirmed: 'hobby'
+            }
+          }
+        ]
+      }
+    });
+
+    await store.dispatch(actions.deleteCategory('food'));
+
+    const calledActions = store.getActions();
+
+    expect(calledActions[0]).toEqual({
+      type: actions.DELETE_CATEGORY_START,
+      categoryId: 'food'
+    });
+
+    expect(calledActions[1]).toEqual({
+      type: actions.DELETE_CATEGORY_END,
+      categoryId: 'food',
+      categorizerConfig: {
+        // Expecting it to be trained only on hobby now
+        bayes: '{"categories":{"hobby":true},"docCount":{"hobby":1},"totalDocuments":1,"vocabulary":{"origami":true},"vocabularySize":1,"wordCount":{"hobby":1},"wordFrequencyCount":{"hobby":{"origami":1}},"options":{}}'
+      }
+    });
   });
 });

--- a/src/components/Transactions.js
+++ b/src/components/Transactions.js
@@ -194,12 +194,12 @@ const searchTransactions = createSearchAction('transactions');
 
 const mapDispatchToProps = dispatch => {
   return {
-    handleRowCategoryChange: (rowId, categoryId) => {
-      dispatch(actions.categorizeRow(rowId, categoryId));
+    handleRowCategoryChange: async (rowId, categoryId) => {
+      await dispatch(actions.categorizeRow(rowId, categoryId));
       if (categoryId) dispatch(actions.guessAllCategories());
     },
-    handleRowCategoriesChange: rowCategoryMapping => {
-      dispatch(actions.categorizeRows(rowCategoryMapping));
+    handleRowCategoriesChange: async rowCategoryMapping => {
+      await dispatch(actions.categorizeRows(rowCategoryMapping));
       if (Object.values(rowCategoryMapping).filter(c => !!c).length > 0) dispatch(actions.guessAllCategories());
     },
     handleNewRowCategory: (rowId, categoryName, parentId) => {

--- a/src/components/transactions/TransactionTable.js
+++ b/src/components/transactions/TransactionTable.js
@@ -92,6 +92,8 @@ class TransactionTable extends React.Component {
   }
 
   handleCategorySelect(options) {
+    // Options is sometimes null
+    options = options || [];
     const filterCategories = new Set(options.map(o => o.value));
 
     // Since the category filter might reduce the number of transactions, we

--- a/src/ml.js
+++ b/src/ml.js
@@ -1,0 +1,97 @@
+import bayes from 'bayes';
+import { reverseIndexLookup } from './util';
+
+const retrainBayes = async transactions => {
+  const classifier = bayes();
+  for (const t of transactions) {
+    const description = t.descriptionCleaned || t.description;
+    if (t.category.confirmed && description) {
+      await classifier.learn(description, t.category.confirmed);
+    }
+  }
+  return classifier;
+};
+
+export const retrainCategorizer = async (transactions) => {
+  return {
+    bayes: (await retrainBayes(transactions)).toJson()
+  };
+};
+
+/**
+ * Ensure that our categorizer is up-to-date when transactions get categorized.
+ * 
+ * @param {Object} transactions - The existing transactions to update
+ * @param {Object} categorizerConfig - The category classification configuration to
+ *                                     use for classification.
+ * @param {Object} transactionCategoryMapping - A mapping of transaction IDs to category IDs
+ * @returns {Object} The new categorizer
+ */
+export const updateCategorizer = async (transactions, categorizerConfig, transactionCategoryMapping) => {
+  const rowIds = Object.keys(transactionCategoryMapping);
+  const rowsToCategorizeAsSet = new Set(rowIds);
+
+  // This wouldn't be necessary if the transactions were not stored in an array.
+  const lookup = reverseIndexLookup(transactions);
+
+  // Find the indexes to update.
+  const rowIndexes = rowIds
+    .map(rowId => lookup[rowId])
+    .filter(rowIndex => rowIndex !== null && rowIndex >= 0);
+
+  // Exit early if we can't find the transactions. This shouldn't really
+  // happen...
+  if (rowIndexes.length === 0) return null;
+
+  // If any of the rows already had a confirmed category, assume it's being changed here and thus: Retrain
+  // If the categorizer is empty: Retrain
+  // Otherwise just instantiate it.
+  let classifier;
+  const anyTransactionHasCategory = !!transactions
+    .find(t => rowsToCategorizeAsSet.has(t.id) && t.category.confirmed);
+
+  if (anyTransactionHasCategory || !categorizerConfig.bayes) {
+    // Reset the classifier and re-train on all transactions, except the ones
+    // we are changing here.
+    classifier = await retrainBayes(transactions.filter(t => !rowsToCategorizeAsSet.has(t.id)));
+  } else {
+    classifier = bayes.fromJson(categorizerConfig.bayes);
+  }
+
+  // Atomically update the state
+  for (const i of rowIndexes) {
+    const transaction = transactions[i]
+    const newCategoryId = transactionCategoryMapping[transaction.id];
+
+    // Train on the new category we are about to add.
+    // Note: The category can be the empty string, if it's a reset of the
+    // category. In those cases, we shouldn't train on it...
+    const description = transaction.descriptionCleaned || transaction.description;
+    if (newCategoryId && description) {
+      await classifier.learn(description, newCategoryId);
+    }
+  }
+
+  // Finally, save the classifier and return transactionsn and classifier
+  return { bayes: classifier.toJson() };
+};
+
+/**
+ * Guess the category of the given transactions.
+ * @param {Array} transactions - A list of transactions to guess the category for
+ * @param {Object} categorizerConfig - The categorizer config
+ * @returns {Object} Mapping from transaction ID to category ID
+ */
+export const guessCategory = async (transactions, categorizerConfig) => {
+  if (!categorizerConfig.bayes) return null;
+
+  const guesstimator = bayes.fromJson(categorizerConfig.bayes);
+
+  const transactionCategoryGuessMapping = {};
+  for (const transaction of transactions) {
+    transactionCategoryGuessMapping[transaction.id] =
+      await guesstimator.categorize(transaction.descriptionCleaned);
+  }
+
+  return transactionCategoryGuessMapping;
+};

--- a/src/reducers/categories.js
+++ b/src/reducers/categories.js
@@ -34,7 +34,7 @@ const categoriesReducer = (state = initialCategories, action) => {
           }
         }
       });
-    case actions.DELETE_CATEGORY:
+    case actions.DELETE_CATEGORY_START:
       const indexToDelete = state.data.findIndex(c => c.id === action.categoryId);
       if (indexToDelete < 0) return state;
       return update(state, {

--- a/src/reducers/categories.test.js
+++ b/src/reducers/categories.test.js
@@ -34,12 +34,13 @@ it('should not update the name for an unknon a category ID', () => {
 });
 
 it('should delete a category', () => {
-  const state = reducers({}, actions.deleteCategory('abcd'));
+  const state = reducers({}, actions.deleteCategoryStart('abcd'));
   // They all have the same ID in these tests, but it will delete the first one,
   // which is Bar currently (because of sorting)
   expect(state.categories.data).not.toContainEqual({
     id: 'abcd',
-    name: 'Bar',
+    name: 'Account Transfers',
+    parent: 'abcd'
   });
   expect(state.categories.data).toContainEqual({
     id: 'abcd',

--- a/src/reducers/edit.js
+++ b/src/reducers/edit.js
@@ -117,11 +117,11 @@ const editReducer = (state = initialEditor, action) => {
           }
         }
       });
-    case actions.START_GUESS_ALL_CATEGORIES:
+    case actions.GUESS_ALL_CATEGORIES_START:
       return update(state, {
         isCategoryGuessing: { $set: true }
       });
-    case actions.END_GUESS_ALL_CATEGORIES:
+    case actions.GUESS_ALL_CATEGORIES_END:
       return update(state, {
         isCategoryGuessing: { $set: false }
       });

--- a/src/reducers/edit.test.js
+++ b/src/reducers/edit.test.js
@@ -150,11 +150,11 @@ it('should set parsing to false on parse transaction ending', () => {
 });
 
 it('should handle the guess start action', () => {
-  expect(reducers({}, actions.startGuessAllCategories()).edit.isCategoryGuessing).toEqual(true);
+  expect(reducers({}, actions.guessAllCategoriesStart()).edit.isCategoryGuessing).toEqual(true);
 });
 
 it('should handle the guess end action', () => {
-  expect(reducers({ edit: { isCategoryGuessing: true } }, actions.endGuessAllCategories()).edit.isCategoryGuessing).toEqual(false);
+  expect(reducers({ edit: { isCategoryGuessing: true } }, actions.guessAllCategoriesEnd({})).edit.isCategoryGuessing).toEqual(false);
 });
 
 it('should handle fetch currencies start action', () => {

--- a/src/util.js
+++ b/src/util.js
@@ -278,3 +278,16 @@ export const fillDates = rates => {
 
   return rates;
 };
+
+/**
+ * Get a mapping of IDs to array indices. It is assumed that the objects have a
+ * single ID field.
+ * @param {Array} arr - The array to search through
+ * @returns {Object} - The mapping of ID to array index
+ */
+export const reverseIndexLookup = arr => {
+  return arr.reduce((obj, t, i) => {
+    obj[t.id] = i;
+    return obj;
+  }, {});
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2355,10 +2355,10 @@ batch@0.6.1:
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=
 
-bayes@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/bayes/-/bayes-0.0.7.tgz#357bf74aa887e796de4bf5e922c5631090af8a00"
-  integrity sha1-NXv3SqiH55beS/XpIsVjEJCvigA=
+bayes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/bayes/-/bayes-1.0.0.tgz#5c50b569a6d600653b01bc47626278da20170d11"
+  integrity sha512-dJkTHtGBbOLtrmcm37R44jelbgKalMPXLLmhNceEgeLRJLdDTU2DoEF7L+UqM3m36dve7/Vka4hgaacT7a8Jjw==
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
This commit updates the bayes library to the latest version which now
uses async for learning and classification. This necessitated a rewrite
of the row categorization functionality.

Changes:
- Update bayes to 1.0.0
- Move transaction classification to new ml module
- Use async actions for transaction classification