### PR TITLE
Add more date prefixes, include child categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otb",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.25",

--- a/src/components/Dates.js
+++ b/src/components/Dates.js
@@ -38,6 +38,18 @@ const presets = [
     value: 'last12Months',
     startDate: moment().subtract(12, 'month').startOf('month'),
     endDate: moment().subtract(1, 'month').endOf('month')
+  },
+  {
+    label: `Last Year (${moment().subtract(1, 'year').format('Y')})`,
+    value: 'lastYear',
+    startDate: moment().subtract(1, 'year').startOf('year'),
+    endDate: moment().subtract(1, 'year').endOf('year')
+  },
+  {
+    label: `Previous Year (${moment().subtract(2, 'year').format('Y')})`,
+    value: 'previousYear',
+    startDate: moment().subtract(2, 'year').startOf('year'),
+    endDate: moment().subtract(2, 'year').endOf('year')
   }
 ];
 

--- a/src/components/charts/CategoryExpenses.test.js
+++ b/src/components/charts/CategoryExpenses.test.js
@@ -1,0 +1,152 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import moment from 'moment';
+import { shallow } from 'enzyme';
+import configureStore from 'redux-mock-store';
+import CategoryExpenses from './CategoryExpenses';
+
+describe('CategoryExpenses', () => {
+  const mockStore = configureStore();
+
+  // To keep connected sub-components happy
+  const baseStore = {
+    categories: {
+      data: [
+        {
+          id: 'a',
+          name: 'Food'
+        },
+        {
+          id: 'b',
+          name: 'Groceries',
+          parent: 'a'
+        },
+        {
+          id: 'c',
+          name: 'Home'
+        }
+      ]
+    }
+  };
+
+  // The base properties to pass to CategoryExpenses.
+  const baseProps = {
+    handleCategoryChange: jest.fn(),
+    sortedCategoryExpenses: [
+      {
+        value: {
+          amount: 456,
+          category: {
+            id: 'a'
+          },
+          transactions: [{
+            date: moment('2020-03-10'),
+            amount: 456
+          }]
+        }
+      },
+      {
+        value: {
+          amount: 123,
+          transactions: [{
+            date: moment('2020-03-10'),
+            amount: 123
+          }],
+          category: {
+            id: 'b'
+          }
+        }
+      },
+      {
+        value: {
+          amount: 789,
+          transactions: [{
+            date: moment('2020-03-10'),
+            amount: 789 
+          }],
+          category: {
+            id: 'c'
+          }
+        }
+      },
+    ],
+    categories: {
+      a: {
+        id: 'a',
+        name: 'Food'
+      },
+      b: {
+        id: 'b',
+        name: 'Groceries',
+        parent: 'a'
+      },
+      c: {
+        id: 'c',
+        name: 'Home'
+      }
+    },
+    startDate: moment('2020-03-01'),
+    endDate: moment('2020-03-15'),
+  };
+
+  it('should not filter categories when filter is empty', () => {
+    const store = mockStore(baseStore);
+
+    const container = shallow(
+      <Provider store={store}>
+        <CategoryExpenses
+          {...baseProps}
+          filterCategories={new Set()}
+        />
+      </Provider>
+    );
+    const lineChartProps = container.find('CategoryExpenses')
+      .dive()
+      .find('CategoryLine')
+      .first()
+      .props();
+    
+    expect(lineChartProps.sortedCategoryExpenses).toHaveLength(3);
+  });
+
+  it('should filter specific categories', () => {
+    const store = mockStore(baseStore);
+    const container = shallow(
+      <Provider store={store}>
+        <CategoryExpenses
+          {...baseProps}
+          filterCategories={new Set(['b'])}
+        />
+      </Provider>
+    );
+    const lineChartProps = container.find('CategoryExpenses')
+      .dive()
+      .find('CategoryLine')
+      .first()
+      .props();
+    
+    expect(lineChartProps.sortedCategoryExpenses).toHaveLength(1);
+    expect(lineChartProps.sortedCategoryExpenses[0].value.amount).toEqual(123);
+  });
+
+  it('should filter specific categories and their children', () => {
+    const store = mockStore(baseStore);
+    const container = shallow(
+      <Provider store={store}>
+        <CategoryExpenses
+          {...baseProps}
+          filterCategories={new Set(['a'])}
+        />
+      </Provider>
+    );
+    const lineChartProps = container.find('CategoryExpenses')
+      .dive()
+      .find('CategoryLine')
+      .first()
+      .props();
+    
+    expect(lineChartProps.sortedCategoryExpenses).toHaveLength(2);
+    expect(lineChartProps.sortedCategoryExpenses[0].value.amount).toEqual(456);
+    expect(lineChartProps.sortedCategoryExpenses[1].value.amount).toEqual(123);
+  });
+});

--- a/src/components/charts/CategoryLine.js
+++ b/src/components/charts/CategoryLine.js
@@ -29,6 +29,9 @@ const CategoryLine = props => {
   const data = Object.entries(obj)
     .map(([date, categories]) => {
       const categoryIds = new Set(Object.keys(categories));
+
+      // Add 0 amounts for dates that are missing a specific category ID.
+      // This avoids holes in the graph.
       const missingCategories = [...allCategories]
         .filter(c => !categoryIds.has(c))
         .reduce((o, c) => {


### PR DESCRIPTION
This commit adds two new small features:
- Two extra date presets in the charts page
- When selecting a parent category on the charts page, it automatically
  includes child categories in the charts.